### PR TITLE
[DM] [SASS-1617] Removed injection from the unit test

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -16,13 +16,13 @@
 
 package config
 
-import javax.inject.{Inject, Singleton}
+import com.google.inject.ImplementedBy
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
-@Singleton
-class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) {
+import javax.inject.Inject
 
+class BackendAppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) extends AppConfig {
   val authBaseUrl: String = servicesConfig.baseUrl("auth")
   val auditingEnabled: Boolean = config.get[Boolean]("auditing.enabled")
   val graphiteHost: String     = config.get[String]("microservice.metrics.graphite.host")
@@ -31,4 +31,16 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   val environment: String = config.get[String]("microservice.services.des.environment")
   val authorisationToken: String = config.get[String]("microservice.services.des.authorisation-token")
+}
+
+@ImplementedBy(classOf[BackendAppConfig])
+trait AppConfig  {
+  val authBaseUrl: String
+  val auditingEnabled: Boolean
+  val graphiteHost: String
+
+  val desBaseUrl: String
+
+  val environment: String
+  val authorisationToken: String
 }

--- a/it/api/DeleteOrIgnoreEmploymentExpensesITest.scala
+++ b/it/api/DeleteOrIgnoreEmploymentExpensesITest.scala
@@ -18,7 +18,7 @@ package api
 
 import helpers.WiremockSpec
 import models.ToRemove.{All, Customer, HmrcHeld}
-import models.{DesErrorBodyModel, Expenses, ExpensesType, IgnoreExpenses}
+import models.{DesErrorBodyModel, IgnoreExpenses}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import play.api.http.Status._

--- a/it/connectors/CreateOrAmendEmploymentExpensesConnectorSpec.scala
+++ b/it/connectors/CreateOrAmendEmploymentExpensesConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import com.github.tomakehurst.wiremock.http.HttpHeader
-import config.AppConfig
+import config.{AppConfig, BackendAppConfig}
 import helpers.WiremockSpec
 import models._
 import play.api.Configuration
@@ -32,7 +32,7 @@ class CreateOrAmendEmploymentExpensesConnectorSpec extends WiremockSpec {
   lazy val connector: CreateOrAmendEmploymentExpensesConnector = app.injector.instanceOf[CreateOrAmendEmploymentExpensesConnector]
 
   lazy val httpClient: HttpClient = app.injector.instanceOf[HttpClient]
-  def appConfig(desHost: String): AppConfig = new AppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
+  def appConfig(desHost: String): AppConfig = new BackendAppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
     override val desBaseUrl: String = s"http://$desHost:$wireMockPort"
   }
 

--- a/it/connectors/DeleteOverrideEmploymentExpensesConnectorSpec.scala
+++ b/it/connectors/DeleteOverrideEmploymentExpensesConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import com.github.tomakehurst.wiremock.http.HttpHeader
-import config.AppConfig
+import config.{AppConfig, BackendAppConfig}
 import helpers.WiremockSpec
 import models.{DesErrorBodyModel, DesErrorModel}
 import org.scalatestplus.play.PlaySpec
@@ -33,7 +33,7 @@ class DeleteOverrideEmploymentExpensesConnectorSpec extends PlaySpec with Wiremo
   lazy val connector: DeleteOverrideEmploymentExpensesConnector = app.injector.instanceOf[DeleteOverrideEmploymentExpensesConnector]
   lazy val httpClient: HttpClient = app.injector.instanceOf[HttpClient]
 
-  def appConfig(desHost: String): AppConfig = new AppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
+  def appConfig(desHost: String): AppConfig = new BackendAppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
     override val desBaseUrl: String = s"http://$desHost:$wireMockPort"
   }
 

--- a/it/connectors/GetEmploymentExpensesConnectorSpec.scala
+++ b/it/connectors/GetEmploymentExpensesConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import com.github.tomakehurst.wiremock.http.HttpHeader
-import config.AppConfig
+import config.{AppConfig, BackendAppConfig}
 import connectors.GetEmploymentExpensesConnectorSpec.expectedResponseBody
 import helpers.WiremockSpec
 import models.{DesErrorBodyModel, DesErrorModel, GetEmploymentExpensesModel}
@@ -33,7 +33,7 @@ class GetEmploymentExpensesConnectorSpec extends WiremockSpec {
   lazy val connector: GetEmploymentExpensesConnector = app.injector.instanceOf[GetEmploymentExpensesConnector]
 
   lazy val httpClient: HttpClient = app.injector.instanceOf[HttpClient]
-  def appConfig(desHost: String): AppConfig = new AppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
+  def appConfig(desHost: String): AppConfig = new BackendAppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
     override val desBaseUrl: String = s"http://$desHost:$wireMockPort"
   }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,12 +4,12 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-backend-play-28"  % "5.6.0",
+    "uk.gov.hmrc"             %% "bootstrap-backend-play-28"  % "5.16.0",
     "com.fasterxml.jackson.module"  %%  "jackson-module-scala"      % "2.12.2"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % "5.6.0"                 % Test,
+    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % "5.16.0"                % Test,
     "org.scalatest"           %% "scalatest"                % "3.2.9"                 % Test,
     "com.typesafe.play"       %% "play-test"                % current                 % Test,
     "org.pegdown"             %  "pegdown"                  % "1.6.0"                 % "test, it",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+class MockAppConfig extends AppConfig {
+  override val authBaseUrl: String = "/auth"
+  override val auditingEnabled: Boolean = true
+  override val graphiteHost: String = "/graphite"
+  override val desBaseUrl: String = "/des"
+  override val environment: String = "test"
+  override val authorisationToken: String = "secret"
+}

--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.http.HeaderNames._
 import uk.gov.hmrc.http.{Authorization, HeaderCarrier, SessionId}
 import utils.TestUtils
 
-class DesConnectorSpec extends TestUtils{
+class DesConnectorSpec extends TestUtils {
 
   class FakeConnector(override val appConfig: AppConfig) extends DesConnector {
     def headerCarrierTest(url: String)(hc: HeaderCarrier): HeaderCarrier = desHeaderCarrier(url)(hc)

--- a/test/controllers/CreateOrAmendEmploymentExpensesControllerSpec.scala
+++ b/test/controllers/CreateOrAmendEmploymentExpensesControllerSpec.scala
@@ -21,6 +21,7 @@ import models.{CreateExpensesRequestModel, DesErrorBodyModel, DesErrorModel}
 import org.scalamock.handlers.CallHandler5
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout}
 import services.CreateOrAmendEmploymentExpensesService
@@ -32,24 +33,26 @@ import scala.concurrent.{ExecutionContext, Future}
 class CreateOrAmendEmploymentExpensesControllerSpec extends TestUtils {
 
 
-  val mockService = mock[CreateOrAmendEmploymentExpensesService]
+  val mockService: CreateOrAmendEmploymentExpensesService = mock[CreateOrAmendEmploymentExpensesService]
   val controller = new CreateOrAmendEmploymentExpensesController(mockService, authorisedAction, mockControllerComponents)
 
   val nino: String = "123456789"
   val mtditid: String = "1234567890"
   val taxYear: Int = 2022
 
-  val fakePutRequest = FakeRequest("PUT", "/some_path_tbc").withHeaders("mtditid" -> mtditid)
+  val fakePutRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("PUT", "/some_path_tbc").withHeaders("mtditid" -> mtditid)
 
   val serverErrorModel: DesErrorBodyModel = DesErrorBodyModel("SERVER_ERROR", "Internal server error")
-
+  
+  //noinspection ScalaStyle
   def mockCreateOrAmendEmploymentExpensesSuccess(): CallHandler5[String, Int, CreateExpensesRequestModel, HeaderCarrier, ExecutionContext, Future[CreateOrAmendEmploymentExpenseResponse]] = {
     val response: CreateOrAmendEmploymentExpenseResponse = Right(())
     (mockService.createOrAmendEmploymentExpenses(_: String, _: Int, _: CreateExpensesRequestModel)(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *, *)
       .returning(Future.successful(response))
   }
-
+  
+  //noinspection ScalaStyle
   def mockCreateOrAmendEmploymentExpensesError(): CallHandler5[String, Int, CreateExpensesRequestModel, HeaderCarrier, ExecutionContext, Future[CreateOrAmendEmploymentExpenseResponse]] = {
     val response: CreateOrAmendEmploymentExpenseResponse = Left(DesErrorModel(INTERNAL_SERVER_ERROR, serverErrorModel))
     (mockService.createOrAmendEmploymentExpenses(_: String, _: Int, _: CreateExpensesRequestModel)(_: HeaderCarrier, _: ExecutionContext))

--- a/test/controllers/DeleteOrIgnoreEmploymentExpensesControllerSpec.scala
+++ b/test/controllers/DeleteOrIgnoreEmploymentExpensesControllerSpec.scala
@@ -45,6 +45,7 @@ class DeleteOrIgnoreEmploymentExpensesControllerSpec extends TestUtils {
 
   "deleteOverrideEmploymentExpenses" when {
 
+    //noinspection ScalaStyle
     def mockDeleteOverrideEmploymentExpensesSuccess(): CallHandler5[String, ToRemove, Int, HeaderCarrier, ExecutionContext, Future[DeleteOverrideEmploymentExpensesResponse]] = {
       val response: DeleteOverrideEmploymentExpensesResponse = Right(())
       (deleteOverrideEmploymentExpensesService.deleteOrIgnoreEmploymentExpenses(_: String, _: ToRemove, _: Int)(_: HeaderCarrier, _: ExecutionContext))
@@ -52,6 +53,7 @@ class DeleteOrIgnoreEmploymentExpensesControllerSpec extends TestUtils {
         .returning(Future.successful(response))
     }
 
+    //noinspection ScalaStyle
     def mockDeleteOverrideEmploymentExpensesFailure(httpStatus: Int): CallHandler5[String, ToRemove, Int, HeaderCarrier, ExecutionContext, Future[DeleteOverrideEmploymentExpensesResponse]] = {
       val error: DeleteOverrideEmploymentExpensesResponse = Left(DesErrorModel(httpStatus, DesErrorBodyModel("DES_CODE", "DES_REASON")))
       (deleteOverrideEmploymentExpensesService.deleteOrIgnoreEmploymentExpenses(_: String, _: ToRemove, _: Int)(_: HeaderCarrier, _: ExecutionContext))

--- a/test/services/CreateOrAmendEmploymentExpensesServiceSpec.scala
+++ b/test/services/CreateOrAmendEmploymentExpensesServiceSpec.scala
@@ -20,7 +20,7 @@ import connectors.CreateOrAmendEmploymentExpensesConnector
 import connectors.httpParsers.CreateOrAmendEmploymentExpensesHttpParser.CreateOrAmendEmploymentExpenseResponse
 import models._
 import org.scalamock.handlers.CallHandler4
-import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR}
+import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.TestUtils
 

--- a/test/utils/TestUtils.scala
+++ b/test/utils/TestUtils.scala
@@ -20,13 +20,12 @@ import akka.actor.ActorSystem
 import akka.stream.SystemMaterializer
 import com.codahale.metrics.SharedMetricRegistries
 import common.{EnrolmentIdentifiers, EnrolmentKeys}
-import config.AppConfig
+import config.{AppConfig, MockAppConfig}
 import controllers.predicates.AuthorisedAction
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, DefaultActionBuilder, Result}
 import play.api.test.{FakeRequest, Helpers}
 import services.AuthService
@@ -40,7 +39,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Awaitable, ExecutionContext, Future}
 
-trait TestUtils extends AnyWordSpec with Matchers with MockFactory with GuiceOneAppPerSuite with BeforeAndAfterEach {
+trait TestUtils extends AnyWordSpec with Matchers with MockFactory with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -56,7 +55,7 @@ trait TestUtils extends AnyWordSpec with Matchers with MockFactory with GuiceOne
   val fakeRequestWithMtditid: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession("MTDITID" -> "1234567890")
   implicit val emptyHeaderCarrier: HeaderCarrier = HeaderCarrier()
 
-  val mockAppConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  val mockAppConfig: AppConfig = new MockAppConfig
   implicit val mockControllerComponents: ControllerComponents = Helpers.stubControllerComponents()
   implicit val mockExecutionContext: ExecutionContext = ExecutionContext.Implicits.global
   implicit val mockAuthConnector: AuthConnector = mock[AuthConnector]


### PR DESCRIPTION
### Description
Updated the unit test to no longer use injection. They now correctly use a MockAppConfig that extends the AppConfig trait.

[SASS-739 (Root story)](https://jira.tools.tax.service.gov.uk/browse/SASS-739)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [x]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [x]  Have you addressed warnings where appropriate?
- [x]  Have you rebased against the current version of main?
- [x]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [x]  Have you checked the PR Builder passes?
